### PR TITLE
Update Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ SUBDIRS = \
 	ui 
 
 # Lugar de instalación de la documentación estandar
-gelidedocdir = ${prefix}/doc/gelide
+gelidedocdir = ${prefix}/share/doc/gelide
 # Archivos de documentación estandar a instalar
 gelidedoc_DATA = \
 	AUTHORS \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,7 +1,7 @@
 ## Process this file with automake to produce Makefile.in
 
 # Lugar de instalación de la documentación
-gelide_docdir = ${prefix}/doc/gelide
+gelide_docdir = ${prefix}/share/doc/gelide
 gelide_doc_DATA = \
 	SystemsAndEmulators-HowTo.es_ES.txt \
 	Gelide-configuration-file-format.txt


### PR DESCRIPTION
Según http://www.pathname.com/fhs/pub/fhs-2.3.html#SPECIFICOPTIONS15 lo correcto es utilizar el directorio estandar /usr/share/doc y no /usr/doc. Se observó al actualizar el paquete de AUR:
namcap gelide-git-0.1.5.g0db66d3-1-x86_64.pkg.tar.xz
gelide-git W: File (usr/doc/) exists in a non-standard directory.
gelide-git W: File (usr/doc/gelide/) exists in a non-standard directory.
gelide-git W: File (usr/doc/gelide/README) exists in a non-standard directory.
gelide-git W: File (usr/doc/gelide/NEWS) exists in a non-standard directory.
gelide-git W: File (usr/doc/gelide/INSTALL) exists in a non-standard directory.
gelide-git W: File (usr/doc/gelide/COPYING) exists in a non-standard directory.
gelide-git W: File (usr/doc/gelide/ChangeLog) exists in a non-standard directory.
gelide-git W: File (usr/doc/gelide/AUTHORS) exists in a non-standard directory.
gelide-git W: File (usr/doc/gelide/Gelide-configuration-file-format.txt) exists in a non-standard directory.
gelide-git W: File (usr/doc/gelide/SystemsAndEmulators-HowTo.es_ES.txt) exists in a non-standard directory.
